### PR TITLE
Add loggers for Vim and IDE

### DIFF
--- a/bin/rdebug-ide
+++ b/bin/rdebug-ide
@@ -20,6 +20,11 @@ class RdebugIde
     Debugger.wait_connection = true
     Debugger.printer = Printers::Xml.new
     Debugger.const_set("PROG_SCRIPT", ARGV.shift)
+    Debugger::Xml.logger = if options.debug_mode
+      Debugger::Xml::Ide::Logger.new
+    else
+      Debugger::Xml::FakeLogger.new
+    end
   end
 
   def run
@@ -61,7 +66,10 @@ class RdebugIde
 
     def opts
       @opts ||= begin
-        @options = OpenStruct.new(host: "127.0.0.1", port: 12345, stop: false, tracing: false, wait_for_start: true, int_handler: true)
+        @options = OpenStruct.new(
+          host: "127.0.0.1", port: 12345, stop: false, tracing: false, wait_for_start: true,
+          int_handler: true, debug_mode: false
+        )
         opts = OptionParser.new do |opts|
           opts.banner = %{
             Using rdebug-ide
@@ -71,6 +79,7 @@ class RdebugIde
           opts.separator ""
           opts.separator "Options:"
           opts.on("-h", "--host HOST", "Host name used for remote debugging") { |host| @options.host = host }
+          opts.on("-d", "--debug", "Enable debug mode") { |host| @options.debug_mode = true }
           opts.on("--cport PORT", Integer, "Port used for control commands") { |cport| @options.cport = cport }
           opts.on("-p", "--port PORT", Integer, "Port used for remote debugging") { |port| @options.port = port }
           opts.on("--wait", String, "Wait for 'start' command") do |bool|

--- a/bin/rdebug-vim
+++ b/bin/rdebug-vim
@@ -16,6 +16,11 @@ class RdebugVim
     Debugger.wait_for_start = true
     Debugger.printer = Printers::Xml.new
     Debugger.const_set("PROG_SCRIPT", options.script)
+    Debugger::Xml.logger = if options.debug_mode
+       Debugger::Xml::Vim::Logger.new(options.logger_file)
+    else
+       Debugger::Xml::FakeLogger.new
+    end
   end
 
   def run

--- a/lib/debugger/xml.rb
+++ b/lib/debugger/xml.rb
@@ -1,3 +1,11 @@
 require "debugger"
 require "debugger/printers/xml"
 Dir.glob(File.expand_path("../**/*.rb", __FILE__)).each { |f| require f }
+
+module Debugger
+  module Xml
+    class << self
+      attr_accessor :logger
+    end
+  end
+end

--- a/lib/debugger/xml/extensions/vim_server.rb
+++ b/lib/debugger/xml/extensions/vim_server.rb
@@ -5,29 +5,37 @@ module Debugger
 
     def start_for_vim(options)
       return if @control_thread
+      Xml.logger.puts("Going to daemonize");
       daemonize!
+      Xml.logger.puts("Successfully daemonized");
       $stdout.reopen(options.output_file, 'w')
       $stdout.sync
       $stderr.reopen($stdout)
+      Xml.logger.puts("Redirected stderr");
       @mutex = Mutex.new
       @proceed = ConditionVariable.new
       start
+      Xml.logger.puts("Started debugger");
       File.unlink(options.socket) if File.exist?(options.socket)
       server = UNIXServer.new(options.socket)
       Xml::Vim::Notification.new("establish_connection", options).send
+      Xml.logger.puts("Sent 'established_connection' command");
       @control_thread = DebugThread.new do
         begin
           while (session = server.accept)
+            Xml.logger.puts("Accepted connection");
             interface = Xml::Vim::Interface.new(session, options)
             processor = Xml::Vim::ControlCommandProcessor.new(interface)
             self.handler = Xml::Vim::Processor.new(interface)
+            Xml.logger.puts("Going to process commands");
             processor.process_commands
           end
         rescue Exception => e
-          puts "INTERNAL ERROR!!! #{$!}" rescue nil
-          puts $!.backtrace.map{|l| "\t#{l}"}.join("\n") rescue nil
+          Xml.logger.puts("INTERNAL ERROR!!! #{$!}") rescue nil
+          Xml.logger.puts($!.backtrace.map{|l| "\t#{l}"}.join("\n")) rescue nil
           raise e
         ensure
+          Xml.logger.puts("Closing server");
           server.close
         end
       end

--- a/lib/debugger/xml/fake_logger.rb
+++ b/lib/debugger/xml/fake_logger.rb
@@ -1,0 +1,11 @@
+module Debugger
+  module Xml
+    class FakeLogger
+      def initialize(*args)
+      end
+
+      def puts(*args)
+      end
+    end
+  end
+end

--- a/lib/debugger/xml/ide/interface.rb
+++ b/lib/debugger/xml/ide/interface.rb
@@ -50,7 +50,9 @@ module Debugger
         def read_command(*args)
           result = non_blocking_gets
           raise IOError unless result
-          result.chomp
+          result.chomp.tap do |r|
+            Xml.logger.puts("Read command: #{r}")
+          end
         end
 
         def readline_support?
@@ -58,7 +60,10 @@ module Debugger
         end
 
         def print(*args)
-          @socket.printf(*escape_input(args))
+          escaped_args = escape_input(args)
+          value = escaped_args.first % escaped_args[1..-1]
+          Xml.logger.puts("Going to print: #{value}")
+          @socket.printf(value)
         end
 
       end

--- a/lib/debugger/xml/ide/logger.rb
+++ b/lib/debugger/xml/ide/logger.rb
@@ -1,0 +1,11 @@
+module Debugger
+  module Xml
+    module Ide
+      class Logger
+        def puts(string)
+          $stderr.puts(string)
+        end
+      end
+    end
+  end
+end

--- a/lib/debugger/xml/vim/interface.rb
+++ b/lib/debugger/xml/vim/interface.rb
@@ -11,7 +11,10 @@ module Debugger
         end
 
         def print(*args)
-          @output << sprintf(*escape_input(args))
+          escaped_args = escape_input(args)
+          value = escaped_args.first % escaped_args[1..-1]
+          Xml.logger.puts("Going to print: #{value}")
+          @output << sprintf(value)
         end
 
         def send_response

--- a/lib/debugger/xml/vim/logger.rb
+++ b/lib/debugger/xml/vim/logger.rb
@@ -1,0 +1,18 @@
+module Debugger
+  module Xml
+    module Vim
+      class Logger
+        def initialize(logger_file)
+          @logger_file = logger_file
+        end
+
+        def puts(string)
+          File.open(@logger_file, 'a') do |f|
+            # match vim redir style new lines, rather than trailing
+            f << "\ndebugger-xml, #{Time.now.strftime("%H:%M:%S")} : #{string.chomp}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,4 @@ require 'debugger/xml'
 require 'debugger/test'
 
 $debugger_test_dir = File.expand_path("..", __FILE__)
+Debugger::Xml.logger = Debugger::Xml::FakeLogger.new


### PR DESCRIPTION
Added 3 loggers:
- Vim Logger, which just appends lines to the given log file
- IDE logger, which just writes to $stderr
- Fake logger, which doesn't do anything

We use Fake logger when debug mode is disabled, or for tests.

@os97673, could you please check it out, do you have everything you need for your RubyMine integration here? Or maybe you'd want to add/change something?

Thanks!
