### PR TITLE
#printf evaluates "%", but we do not need this

### DIFF
--- a/lib/debugger/xml/ide/interface.rb
+++ b/lib/debugger/xml/ide/interface.rb
@@ -63,7 +63,7 @@ module Debugger
           escaped_args = escape_input(args)
           value = escaped_args.first % escaped_args[1..-1]
           Xml.logger.puts("Going to print: #{value}")
-          @socket.printf(value)
+          @socket.print(value)
         end
 
       end


### PR DESCRIPTION
The problem has been reported against RubyMine (http://youtrack.jetbrains.com/issue/RUBY-14642)
@astashov do you have any particular reasons to use printf here?
